### PR TITLE
Re-init on invalid auth

### DIFF
--- a/modules/HomematicIP.py
+++ b/modules/HomematicIP.py
@@ -34,6 +34,9 @@ def getdata():
     global h
 
     if not h.get_current_state():
+        # Re-init to prevent stale access tokens
+        h.init(config["accesspointid"])
+
         if not h.get_current_state():
             if not h.get_current_state():
                 return


### PR DESCRIPTION
Somehow the connection is lost after some days, try to re-init. This works for me to get the reporting more reliable.